### PR TITLE
POOL-1190 Add weekly prize value

### DIFF
--- a/packages/api-entrypoint/package.json
+++ b/packages/api-entrypoint/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "start": "wrangler dev",
-    "publish": "wrangler publish",
+    "publish": "wrangler publish --env production",
     "build": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write '**/*.{js,css,json,md}'"

--- a/packages/api-entrypoint/package.json
+++ b/packages/api-entrypoint/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.1",
     "@ethersproject/units": "^5.1.0",
-    "@pooltogether/api-runner": "1.2.18",
+    "@pooltogether/api-runner": "1.2.20",
     "@pooltogether/current-pool-data": "3.4.10",
     "@pooltogether/etherplex": "1.1.1",
     "@pooltogether/evm-chains-extended": "^0.4.3",

--- a/packages/api-entrypoint/wrangler.toml.example
+++ b/packages/api-entrypoint/wrangler.toml.example
@@ -2,8 +2,10 @@ name = "pooltogether-api"
 type = "webpack"
 
 account_id = ""
-zone_id = ""
-route = "*.pooltogether-api.com/*"
 workers_dev = true
 webpack_config = "webpack.config.js"
-vars = { ENVIRONMENT = 'dev' }
+
+# Required for publishing
+[env.production]
+zone_id = ""
+route = "*.pooltogether-api.com/*"

--- a/packages/api-entrypoint/yarn.lock
+++ b/packages/api-entrypoint/yarn.lock
@@ -798,10 +798,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-3.4.0.tgz#7674c73c643a509f1b90c509e3e72fe9aae02aeb"
   integrity sha512-7wBcbukDqWZt/B1zjb7zyeWq+AC7rx7nGln7/hPxHdKd8PAiiteXd51Cp2KmGP8qaY0/TXh/fQLsA082LWp8Zw==
 
-"@pooltogether/api-runner@1.2.18":
-  version "1.2.18"
-  resolved "https://registry.yarnpkg.com/@pooltogether/api-runner/-/api-runner-1.2.18.tgz#0430b86649e265428a3d6daa2482464acb661b42"
-  integrity sha512-m0bHQArQCWRlhvFBXEwmKXQ8uz6T95de0rTqwvXqaS/6Mwxig3nvq2aTm9cb7EzoRVF1LoorqMv5oSplrRyfhA==
+"@pooltogether/api-runner@1.2.20":
+  version "1.2.20"
+  resolved "https://registry.yarnpkg.com/@pooltogether/api-runner/-/api-runner-1.2.20.tgz#c38ae55b7a9c3ed85e3b509812ead8ac4bf5ad26"
+  integrity sha512-uzkVQf2X50y6S+7i+HCsIDgjdMC9tk7nkSoNtti+HMuFlDfACk7LrgppiYwn5H7rDHXBsDU9U4ggWCau/pzymA==
   dependencies:
     "@ethersproject/abi" "^5.1.1"
     "@ethersproject/units" "^5.1.0"

--- a/packages/api-runner/package.json
+++ b/packages/api-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pooltogether/api-runner",
-  "version": "1.2.18",
+  "version": "1.2.20",
   "author": "PoolTogether <hello@pooltogether.com>",
   "license": "MIT",
   "description": "Gain more insight when testing the API code in a regular node enviroment",


### PR DESCRIPTION
Inside the `prize` part of the pool response we'll now get:
```
  "weeklyTotalValueUsd": "5580.3",
  "weeklyTotalValueUsdScaled": {
      "type": "BigNumber",
      "hex": "0x0883ce"
  }
```
We find prizes per week then multiply the internal prize (yield) out by that. Stake pools are capped at 1 per week since we can't guarantee there's another prize.